### PR TITLE
Add manual map angle measurement overlay

### DIFF
--- a/app/src/main/java/com/bizzkoot/qiblafinder/ui/location/AngleMeasurementModels.kt
+++ b/app/src/main/java/com/bizzkoot/qiblafinder/ui/location/AngleMeasurementModels.kt
@@ -1,0 +1,16 @@
+package com.bizzkoot.qiblafinder.ui.location
+
+import android.graphics.Bitmap
+import android.graphics.PointF
+
+/**
+ * Captured snapshot of the manual location map used by the angle measurement overlay.
+ * The bitmap represents the frozen map image and the Qibla line coordinates are
+ * expressed relative to the bitmap's original dimensions.
+ */
+data class AngleMeasurementSnapshot(
+    val bitmap: Bitmap,
+    val qiblaLineStart: PointF,
+    val qiblaLineEnd: PointF,
+    val qiblaBearing: Double
+)

--- a/app/src/main/java/com/bizzkoot/qiblafinder/ui/location/AngleMeasurementOverlay.kt
+++ b/app/src/main/java/com/bizzkoot/qiblafinder/ui/location/AngleMeasurementOverlay.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
 import kotlin.math.abs
 import kotlin.math.atan2
 import kotlin.math.roundToInt
@@ -115,10 +117,13 @@ fun AngleMeasurementOverlay(
                 }
         ) {
             Canvas(modifier = Modifier.fillMaxSize()) {
+                val dstOffset = IntOffset(offsetX.roundToInt(), offsetY.roundToInt())
+                val dstSize = IntSize(drawWidth.roundToInt().coerceAtLeast(1), drawHeight.roundToInt().coerceAtLeast(1))
+
                 drawImage(
                     image = imageBitmap,
-                    topLeft = Offset(offsetX, offsetY),
-                    size = androidx.compose.ui.geometry.Size(drawWidth, drawHeight)
+                    dstOffset = dstOffset,
+                    dstSize = dstSize
                 )
 
                 drawLine(

--- a/app/src/main/java/com/bizzkoot/qiblafinder/ui/location/AngleMeasurementOverlay.kt
+++ b/app/src/main/java/com/bizzkoot/qiblafinder/ui/location/AngleMeasurementOverlay.kt
@@ -1,0 +1,227 @@
+package com.bizzkoot.qiblafinder.ui.location
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import kotlin.math.abs
+import kotlin.math.atan2
+import kotlin.math.roundToInt
+
+@Composable
+fun AngleMeasurementOverlay(
+    snapshot: AngleMeasurementSnapshot,
+    lastMeasuredAngle: Double?,
+    onAngleMeasured: (Double) -> Unit,
+    onClearMeasurement: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val bitmap = snapshot.bitmap
+    val imageBitmap = remember(bitmap) { bitmap.asImageBitmap() }
+    val qiblaStart = remember(snapshot) { Offset(snapshot.qiblaLineStart.x, snapshot.qiblaLineStart.y) }
+    val qiblaEnd = remember(snapshot) { Offset(snapshot.qiblaLineEnd.x, snapshot.qiblaLineEnd.y) }
+
+    var touchPoints by remember { mutableStateOf<List<Offset>>(emptyList()) }
+    var calculatedAngle by remember { mutableStateOf(lastMeasuredAngle) }
+
+    LaunchedEffect(lastMeasuredAngle) {
+        calculatedAngle = lastMeasuredAngle
+    }
+
+    BoxWithConstraints(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.85f))
+    ) {
+        val density = LocalDensity.current
+        val containerWidth = with(density) { maxWidth.toPx() }
+        val containerHeight = with(density) { maxHeight.toPx() }
+        val imageWidth = bitmap.width.coerceAtLeast(1).toFloat()
+        val imageHeight = bitmap.height.coerceAtLeast(1).toFloat()
+
+        val imageAspect = imageWidth / imageHeight
+        val containerAspect = if (containerHeight == 0f) 1f else containerWidth / containerHeight
+
+        val scale = if (containerAspect > imageAspect) {
+            containerHeight / imageHeight
+        } else {
+            containerWidth / imageWidth
+        }
+
+        val drawWidth = imageWidth * scale
+        val drawHeight = imageHeight * scale
+        val offsetX = (containerWidth - drawWidth) / 2f
+        val offsetY = (containerHeight - drawHeight) / 2f
+
+        val qiblaStartScaled = Offset(offsetX + qiblaStart.x * scale, offsetY + qiblaStart.y * scale)
+        val qiblaEndScaled = Offset(offsetX + qiblaEnd.x * scale, offsetY + qiblaEnd.y * scale)
+
+        val projectedTouches = touchPoints.map { Offset(offsetX + it.x * scale, offsetY + it.y * scale) }
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(imageWidth, imageHeight, offsetX, offsetY, scale) {
+                    detectTapGestures { pointerPosition ->
+                        val imageX = (pointerPosition.x - offsetX) / scale
+                        val imageY = (pointerPosition.y - offsetY) / scale
+
+                        if (imageX in 0f..imageWidth && imageY in 0f..imageHeight) {
+                            val newPoint = Offset(imageX, imageY)
+                            touchPoints = when (touchPoints.size) {
+                                0 -> listOf(newPoint)
+                                1 -> listOf(touchPoints.first(), newPoint)
+                                else -> listOf(newPoint)
+                            }
+
+                            if (touchPoints.size == 2) {
+                                val angle = calculateAngleDifference(
+                                    touchPoints[0],
+                                    touchPoints[1],
+                                    qiblaStart,
+                                    qiblaEnd
+                                )
+                                calculatedAngle = angle
+                                onAngleMeasured(angle)
+                            }
+                        }
+                    }
+                }
+        ) {
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                drawImage(
+                    image = imageBitmap,
+                    topLeft = Offset(offsetX, offsetY),
+                    size = androidx.compose.ui.geometry.Size(drawWidth, drawHeight)
+                )
+
+                drawLine(
+                    color = Color(0xFF81C784),
+                    start = qiblaStartScaled,
+                    end = qiblaEndScaled,
+                    strokeWidth = 4.dp.toPx()
+                )
+
+                if (projectedTouches.size == 2) {
+                    drawLine(
+                        color = Color.Yellow,
+                        start = projectedTouches[0],
+                        end = projectedTouches[1],
+                        strokeWidth = 3.dp.toPx()
+                    )
+                }
+
+                projectedTouches.forEach { point ->
+                    drawCircle(
+                        color = Color.Yellow,
+                        radius = 6.dp.toPx(),
+                        center = point
+                    )
+                }
+            }
+
+            Column(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(horizontal = 24.dp, vertical = 24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = buildString {
+                        append("Angle to Qibla")
+                        calculatedAngle?.let { append(": ${it.roundToInt()}°") }
+                    },
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.Center
+                )
+                Text(
+                    text = "Qibla bearing ${snapshot.qiblaBearing.roundToInt()}°",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = Color.White,
+                    textAlign = TextAlign.Center
+                )
+                Text(
+                    text = if (touchPoints.size < 2) "Tap two points to draw your reference line" else "Tap again to start a new measurement",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.White.copy(alpha = 0.9f),
+                    textAlign = TextAlign.Center
+                )
+            }
+
+            Row(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(24.dp),
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                TextButton(
+                    onClick = {
+                        touchPoints = emptyList()
+                        calculatedAngle = null
+                        onClearMeasurement()
+                    },
+                    enabled = touchPoints.isNotEmpty() || calculatedAngle != null
+                ) {
+                    Text("Clear", color = Color.White)
+                }
+                Button(onClick = onDismiss) {
+                    Text("Close")
+                }
+            }
+        }
+    }
+}
+
+private fun calculateAngleDifference(
+    userStart: Offset,
+    userEnd: Offset,
+    qiblaStart: Offset,
+    qiblaEnd: Offset
+): Double {
+    val userVector = userEnd - userStart
+    val qiblaVector = qiblaEnd - qiblaStart
+
+    val userMagnitude = userVector.x * userVector.x + userVector.y * userVector.y
+    val qiblaMagnitude = qiblaVector.x * qiblaVector.x + qiblaVector.y * qiblaVector.y
+
+    if (userMagnitude == 0f || qiblaMagnitude == 0f) {
+        return 0.0
+    }
+
+    val userAngle = Math.toDegrees(atan2(userVector.y.toDouble(), userVector.x.toDouble()))
+    val qiblaAngle = Math.toDegrees(atan2(qiblaVector.y.toDouble(), qiblaVector.x.toDouble()))
+
+    var difference = qiblaAngle - userAngle
+    difference = ((difference + 540) % 360) - 180
+
+    return abs(difference)
+}

--- a/app/src/main/java/com/bizzkoot/qiblafinder/ui/location/OpenStreetMapView.kt
+++ b/app/src/main/java/com/bizzkoot/qiblafinder/ui/location/OpenStreetMapView.kt
@@ -26,10 +26,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Canvas as ComposeCanvas
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.graphics.drawscope.withTransform
@@ -37,6 +37,8 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.graphics.Canvas as ComposeCanvas
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp

--- a/app/src/main/java/com/bizzkoot/qiblafinder/ui/location/OpenStreetMapView.kt
+++ b/app/src/main/java/com/bizzkoot/qiblafinder/ui/location/OpenStreetMapView.kt
@@ -1,6 +1,7 @@
 package com.bizzkoot.qiblafinder.ui.location
 
 import android.graphics.Bitmap
+import android.graphics.PointF
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectDragGestures
@@ -23,13 +24,21 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Canvas as ComposeCanvas
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.bizzkoot.qiblafinder.utils.DeviceCapabilitiesDetector
 import kotlinx.coroutines.isActive
@@ -99,6 +108,93 @@ private fun calculateZoomAdaptiveThreshold(digitalZoomFactor: Double, config: Di
     }.coerceAtLeast(5.0) // Minimum threshold
 }
 
+private fun DrawScope.renderMapScene(
+    tileStateCache: Map<String, TileLoadState>,
+    mapType: MapType,
+    tileX: Double,
+    tileY: Double,
+    zoom: Int,
+    digitalZoom: Double,
+    tileManager: OpenStreetMapTileManager,
+    showQiblaDirection: Boolean,
+    qiblaOverlay: QiblaDirectionOverlay
+): SimpleQiblaArrowRenderResult? {
+    val centerX = size.width / 2f
+    val centerY = size.height / 2f
+
+    withTransform({
+        scale(digitalZoom.toFloat(), digitalZoom.toFloat(), pivot = Offset(centerX, centerY))
+    }) {
+        val fractionalTileX = tileX - floor(tileX)
+        val fractionalTileY = tileY - floor(tileY)
+
+        val tileOffsetX = (fractionalTileX * TILE_SIZE).toFloat()
+        val tileOffsetY = (fractionalTileY * TILE_SIZE).toFloat()
+
+        val canvasCenter = Offset(size.width / 2f, size.height / 2f)
+
+        tileStateCache.forEach { (cacheKey, state) ->
+            val tile = parseTileCacheKey(cacheKey)
+            if (tile != null && tile.mapType == mapType) {
+                val drawX = (tile.x - floor(tileX)).toFloat() * TILE_SIZE.toFloat() - tileOffsetX + canvasCenter.x
+                val drawY = (tile.y - floor(tileY)).toFloat() * TILE_SIZE.toFloat() - tileOffsetY + canvasCenter.y
+
+                when (state) {
+                    is TileLoadState.Loading -> {
+                        drawRect(
+                            color = Color.LightGray,
+                            topLeft = Offset(drawX, drawY),
+                            size = androidx.compose.ui.geometry.Size(TILE_SIZE.toFloat(), TILE_SIZE.toFloat())
+                        )
+                    }
+                    is TileLoadState.LowRes -> {
+                        drawImage(state.bitmap.asImageBitmap(), topLeft = Offset(drawX, drawY))
+                    }
+                    is TileLoadState.HighRes -> {
+                        drawImage(state.bitmap.asImageBitmap(), topLeft = Offset(drawX, drawY))
+                    }
+                    is TileLoadState.Failed -> {
+                        drawRect(
+                            color = Color.Gray,
+                            topLeft = Offset(drawX, drawY),
+                            size = androidx.compose.ui.geometry.Size(TILE_SIZE.toFloat(), TILE_SIZE.toFloat())
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    val arrowResult = if (showQiblaDirection) {
+        val (currentLat, currentLng) = PrecisionCoordinateTransformer.highPrecisionTileToLatLng(
+            tileX,
+            tileY,
+            zoom
+        )
+
+        qiblaOverlay.renderSimpleQiblaArrow(
+            drawScope = this,
+            dropPinCenter = Offset(centerX, centerY),
+            userLatitude = currentLat,
+            userLongitude = currentLng,
+            mapType = mapType
+        )
+    } else {
+        null
+    }
+
+    val pinColor = Color.Red
+    drawCircle(color = pinColor, radius = 15f, center = Offset(centerX, centerY))
+    drawCircle(color = Color.White, radius = 3f, center = Offset(centerX, centerY))
+
+    val accuracyInMeters = getAccuracyForZoomWithDigitalZoom(zoom, digitalZoom)
+    val accuracyInPixels = (tileManager.metersToPixels(accuracyInMeters.toFloat(), zoom) * digitalZoom).toFloat()
+    drawCircle(color = Color.Red.copy(alpha = 0.1f), radius = accuracyInPixels, center = Offset(centerX, centerY))
+    drawCircle(color = Color.Red, radius = accuracyInPixels, center = Offset(centerX, centerY), style = Stroke(width = 2f))
+
+    return arrowResult
+}
+
 @Composable
 fun OpenStreetMapView(
     currentLocation: MapLocation,
@@ -114,9 +210,14 @@ fun OpenStreetMapView(
     panelHeight: Int = 0,
     isMapTypeChanging: Boolean = false,
     onRecenterConsumed: () -> Unit = {},
+    measurementRequestToken: Long? = null,
+    onMeasurementSnapshotCaptured: (Long, AngleMeasurementSnapshot) -> Unit = { _, _ -> },
+    onMeasurementSnapshotFailed: (Long) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
+    val density = LocalDensity.current
+    val layoutDirection = LocalLayoutDirection.current
     val tileManager = remember(cacheLimitMb) {
         OpenStreetMapTileManager(context, cacheLimitMb)
     }
@@ -131,6 +232,10 @@ fun OpenStreetMapView(
     var digitalZoomIndicator by remember { mutableStateOf(false) }
     // Viewport-only burst loading when out-of-bounds at high digital zoom
     // Digital zoom policy: always load visible tiles; no buffer
+
+    var canvasSize by remember { mutableStateOf(IntSize.Zero) }
+    var lastArrowResult by remember { mutableStateOf<SimpleQiblaArrowRenderResult?>(null) }
+    var handledMeasurementToken by remember { mutableStateOf<Long?>(null) }
     
     // --- Out-of-bounds and refresh state ---
     var outOfBoundsState by remember { mutableStateOf(OutOfBoundsState()) }
@@ -533,95 +638,110 @@ fun OpenStreetMapView(
                 )
             }
     ) {
-        Canvas(modifier = Modifier.fillMaxSize()) {
-            val centerX = size.width / 2f
-            val centerY = size.height / 2f
-
-            withTransform({
-                scale(digitalZoom.toFloat(), digitalZoom.toFloat(), pivot = Offset(centerX, centerY))
-            }) {
-                val fractionalTileX = tileX - floor(tileX)
-                val fractionalTileY = tileY - floor(tileY)
-
-                val tileOffsetX = (fractionalTileX * TILE_SIZE).toFloat()
-                val tileOffsetY = (fractionalTileY * TILE_SIZE).toFloat()
-
-                // Center point of the canvas, this is where the pin is
-                val canvasCenter = Offset(size.width / 2f, size.height / 2f)
-
-                tileStateCache.forEach { (cacheKey, state) ->
-                    val tile = parseTileCacheKey(cacheKey)
-                    if (tile != null && tile.mapType == mapType) {
-                        val drawX = (tile.x - floor(tileX)).toFloat() * TILE_SIZE.toFloat() - tileOffsetX + canvasCenter.x
-                        val drawY = (tile.y - floor(tileY)).toFloat() * TILE_SIZE.toFloat() - tileOffsetY + canvasCenter.y
-
-                        when (state) {
-                            is TileLoadState.Loading -> {
-                                // Optional: Draw a placeholder rectangle
-                                drawRect(
-                                    color = Color.LightGray,
-                                    topLeft = Offset(drawX, drawY),
-                                    size = androidx.compose.ui.geometry.Size(TILE_SIZE.toFloat(), TILE_SIZE.toFloat())
-                                )
-                            }
-                            is TileLoadState.LowRes -> {
-                                // Draw the low-res bitmap, it will be scaled up by the canvas transform
-                                drawImage(state.bitmap.asImageBitmap(), topLeft = Offset(drawX, drawY))
-                            }
-                            is TileLoadState.HighRes -> {
-                                // Draw the final, sharp high-res bitmap
-                                drawImage(state.bitmap.asImageBitmap(), topLeft = Offset(drawX, drawY))
-                            }
-                            is TileLoadState.Failed -> {
-                                // Optional: Draw an error indicator
-                                drawRect(
-                                    color = Color.Gray,
-                                    topLeft = Offset(drawX, drawY),
-                                    size = androidx.compose.ui.geometry.Size(TILE_SIZE.toFloat(), TILE_SIZE.toFloat())
-                                )
-                                // You could also draw an 'X' or other indicator
-                            }
-                        }
-                    }
-                }
-            }
-
-            // --- Draw Qibla Direction Arrow (Simple, aligned with drop pin) ---
-            if (showQiblaDirection) {
-                // Get the current coordinate that the drop pin represents
-                val (currentLat, currentLng) = PrecisionCoordinateTransformer.highPrecisionTileToLatLng(
-                    tileX, tileY, zoom
-                )
-                
-                // Render simple Qibla arrow using same anchor point as drop pin
-                qiblaOverlay.renderSimpleQiblaArrow(
-                    drawScope = this,
-                    dropPinCenter = Offset(centerX, centerY), // Same as drop pin
-                    userLatitude = currentLat,
-                    userLongitude = currentLng,
-                    mapType = mapType
-                )
-            }
-
-            // --- Draw Location Pin (always at the center of the screen) ---
-            val pinColor = Color.Red
-            drawCircle(color = pinColor, radius = 15f, center = Offset(centerX, centerY))
-            drawCircle(color = Color.White, radius = 3f, center = Offset(centerX, centerY))
-
-            // --- Draw Accuracy Circle (around the pin) ---
-            val accuracyInMeters = getAccuracyForZoomWithDigitalZoom(zoom, digitalZoom)
-            val accuracyInPixels = (tileManager.metersToPixels(accuracyInMeters.toFloat(), zoom) * digitalZoom).toFloat()
-            drawCircle(color = Color.Red.copy(alpha = 0.1f), radius = accuracyInPixels, center = Offset(centerX, centerY))
-            drawCircle(color = Color.Red, radius = accuracyInPixels, center = Offset(centerX, centerY), style = Stroke(width = 2f))
+        Canvas(
+            modifier = Modifier
+                .fillMaxSize()
+                .onSizeChanged { canvasSize = it }
+        ) {
+            lastArrowResult = renderMapScene(
+                tileStateCache = tileStateCache,
+                mapType = mapType,
+                tileX = tileX,
+                tileY = tileY,
+                zoom = zoom,
+                digitalZoom = digitalZoom,
+                tileManager = tileManager,
+                showQiblaDirection = showQiblaDirection,
+                qiblaOverlay = qiblaOverlay
+            )
         }
 
         if (isLoading && tileStateCache.isEmpty()) {
             CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
         }
 
+        LaunchedEffect(measurementRequestToken, canvasSize, lastArrowResult, mapType, digitalZoom, showQiblaDirection) {
+            val token = measurementRequestToken
+            if (token == null) {
+                handledMeasurementToken = null
+                return@LaunchedEffect
+            }
+
+            if (handledMeasurementToken == token) {
+                return@LaunchedEffect
+            }
+
+            if (canvasSize == IntSize.Zero) {
+                return@LaunchedEffect
+            }
+
+            val currentArrow = lastArrowResult
+            if (currentArrow == null) {
+                Timber.w("📍 Measurement snapshot requested but Qibla arrow is unavailable")
+                onMeasurementSnapshotFailed(token)
+                handledMeasurementToken = token
+                return@LaunchedEffect
+            }
+
+            try {
+                val offscreenBitmap = ImageBitmap(canvasSize.width.coerceAtLeast(1), canvasSize.height.coerceAtLeast(1))
+                var snapshotArrow: SimpleQiblaArrowRenderResult? = null
+
+                CanvasDrawScope().draw(
+                    density = density,
+                    layoutDirection = layoutDirection,
+                    canvas = ComposeCanvas(offscreenBitmap),
+                    size = Size(canvasSize.width.toFloat(), canvasSize.height.toFloat())
+                ) {
+                    snapshotArrow = renderMapScene(
+                        tileStateCache = tileStateCache,
+                        mapType = mapType,
+                        tileX = tileX,
+                        tileY = tileY,
+                        zoom = zoom,
+                        digitalZoom = digitalZoom,
+                        tileManager = tileManager,
+                        showQiblaDirection = showQiblaDirection,
+                        qiblaOverlay = qiblaOverlay
+                    )
+                }
+
+                val renderedArrow = snapshotArrow ?: currentArrow
+
+                var bitmap = offscreenBitmap.asAndroidBitmap()
+                var startOffset = renderedArrow.start
+                var endOffset = renderedArrow.end
+
+                if (DeviceCapabilitiesDetector.isLowEndDevice()) {
+                    val scaleFactor = 0.75f
+                    val scaledWidth = (bitmap.width * scaleFactor).roundToInt().coerceAtLeast(1)
+                    val scaledHeight = (bitmap.height * scaleFactor).roundToInt().coerceAtLeast(1)
+                    bitmap = Bitmap.createScaledBitmap(bitmap, scaledWidth, scaledHeight, true)
+                    startOffset = Offset(startOffset.x * scaleFactor, startOffset.y * scaleFactor)
+                    endOffset = Offset(endOffset.x * scaleFactor, endOffset.y * scaleFactor)
+                    Timber.d("📍 Low-end snapshot downscaled to ${scaledWidth}x${scaledHeight}")
+                }
+
+                onMeasurementSnapshotCaptured(
+                    token,
+                    AngleMeasurementSnapshot(
+                        bitmap = bitmap,
+                        qiblaLineStart = PointF(startOffset.x, startOffset.y),
+                        qiblaLineEnd = PointF(endOffset.x, endOffset.y),
+                        qiblaBearing = renderedArrow.bearing
+                    )
+                )
+            } catch (throwable: Throwable) {
+                Timber.e(throwable, "📍 Failed to capture angle measurement snapshot")
+                onMeasurementSnapshotFailed(token)
+            } finally {
+                handledMeasurementToken = token
+            }
+        }
+
         // --- Digital Zoom Indicator ---
         if (digitalZoomIndicator) {
-            val overlayTopPadding = with(LocalDensity.current) { panelHeight.toDp() + 16.dp }
+            val overlayTopPadding = with(density) { panelHeight.toDp() + 16.dp }
             Card(
                 modifier = Modifier
                     .align(Alignment.TopStart)
@@ -712,7 +832,6 @@ fun OpenStreetMapView(
         // Alert removed intentionally (we now auto-load visible tiles in digital zoom)
         
         // --- UI Elements (Zoom, Info) ---
-        val density = LocalDensity.current
         val dynamicTopPadding = with(density) { panelHeight.toDp() + 16.dp }
         Column(modifier = Modifier.align(Alignment.TopEnd).padding(top = dynamicTopPadding, end = 16.dp)) {
             IconButton(

--- a/app/src/main/java/com/bizzkoot/qiblafinder/ui/location/QiblaDirectionOverlay.kt
+++ b/app/src/main/java/com/bizzkoot/qiblafinder/ui/location/QiblaDirectionOverlay.kt
@@ -37,6 +37,15 @@ data class QiblaDirectionState(
 )
 
 /**
+ * Result of rendering the simplified Qibla arrow anchored at the drop pin.
+ */
+data class SimpleQiblaArrowRenderResult(
+    val start: Offset,
+    val end: Offset,
+    val bearing: Double
+)
+
+/**
  * Data class representing viewport bounds for efficient path clipping
  */
 data class ViewportBounds(
@@ -1196,7 +1205,7 @@ class QiblaDirectionOverlay {
         userLatitude: Double,
         userLongitude: Double,
         mapType: MapType
-    ) {
+    ): SimpleQiblaArrowRenderResult? {
         with(drawScope) {
             try {
                 // Calculate Qibla bearing using Great Circle method
@@ -1245,7 +1254,12 @@ class QiblaDirectionOverlay {
                         drawSimpleArrowHead(arrowTip, bearingRad, outlineColor)
                         
                         Timber.d("📍 Simple Qibla arrow rendered: bearing=${String.format("%.1f", qiblaBearing)}°, length=${String.format("%.0f", optimalArrowLength)}px, from=${dropPinCenter}, to=${arrowTip}")
-                        
+
+                        return SimpleQiblaArrowRenderResult(
+                            start = dropPinCenter,
+                            end = arrowTip,
+                            bearing = qiblaBearing
+                        )
                     }
                     is GeodesyResult.Error -> {
                         // Draw error indicator at drop pin center
@@ -1272,12 +1286,12 @@ class QiblaDirectionOverlay {
                         )
                         
                         Timber.w("📍 Qibla calculation error: ${bearingResult.message}")
+                        return null
                     }
                 }
-                
+
             } catch (e: Exception) {
                 Timber.e(e, "📍 Error rendering simple Qibla arrow")
-                
                 // Draw fallback error indicator
                 drawCircle(
                     color = Color.Red.copy(alpha = 0.5f),
@@ -1285,8 +1299,10 @@ class QiblaDirectionOverlay {
                     center = dropPinCenter,
                     style = Stroke(width = 2f)
                 )
+                return null
             }
         }
+        return null
     }
     
     /**

--- a/app/src/main/res/drawable/ic_protractor.xml
+++ b/app/src/main/res/drawable/ic_protractor.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillType="nonZero"
+        android:pathData="M12,4C6.48,4 2,8.48 2,14v6h20v-6C22,8.48 17.52,4 12,4zM20,18H4v-4c0,-4.41 3.59,-8 8,-8s8,3.59 8,8v4z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,10c-2.21,0 -4,1.79 -4,4h2c0,-1.1 0.9,-2 2,-2s2,0.9 2,2h2C16,11.79 14.21,10 12,10z" />
+</vector>


### PR DESCRIPTION
## Summary
- add a frozen-map angle measurement workflow to the manual location screen with a dedicated overlay
- extend the manual location view model and OpenStreetMap renderer to capture map snapshots and expose Qibla line endpoints
- introduce reusable models and UI for displaying the captured image, collecting taps, and reporting measured angles

## Testing
- `./gradlew lint` *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f0adb4050c832a864c0b7c6cb104cd